### PR TITLE
feat: unlink current linked files before switching config contexts

### DIFF
--- a/rc4me/run.py
+++ b/rc4me/run.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict
 import logging
 import click
 
-from rc4me.util import RcDirs, fetch_repo, link_files
+from rc4me.util import RcDirs
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -52,15 +52,14 @@ def get(ctx: Dict[str, RcDirs], repo: str):
     """
     rc_dirs = ctx.obj["rc_dirs"]
     # Init repo variables
-    rc_dirs.set_repo(repo)
-    logger.info("Getting and setting rc4me config: {repo}")
+    logger.info(f"Getting and setting rc4me config: {repo}")
     # Clone repo to rc4me home dir or update existing local config repo
-    fetch_repo(rc_dirs)
+    rc_dirs.fetch_repo(repo)
     # Wait to relink current until after _fetch_repo, since it could fail if
     # the git repo doesn't exist or similar.
-    rc_dirs.relink_current_to(rc_dirs.source)
+    rc_dirs.relink_current_to(rc_dirs.repo)
     # Link rc4me target config to destination
-    link_files(rc_dirs)
+    rc_dirs.link_files()
 
 
 @cli.command()
@@ -76,7 +75,7 @@ def revert(ctx: Dict[str, RcDirs]):
     logger.info("Reverting rc4me config to previous configuration")
     rc_dirs.relink_current_to(rc_dirs.prev.resolve())
     # Link rc4me target config to destination
-    link_files(rc_dirs)
+    rc_dirs.link_files()
 
 
 @cli.command()
@@ -93,7 +92,7 @@ def reset(ctx: Dict[str, RcDirs]):
     logger.info("Restoring rc4me config to initial configuration")
     rc_dirs.relink_current_to(rc_dirs.init)
     # Link rc4me target config to destination
-    link_files(rc_dirs)
+    rc_dirs.link_files()
 
 
 if __name__ == "__main__":

--- a/rc4me/run.py
+++ b/rc4me/run.py
@@ -57,7 +57,7 @@ def get(ctx: Dict[str, RcDirs], repo: str):
     rc_dirs.fetch_repo(repo)
     # Wait to relink current until after _fetch_repo, since it could fail if
     # the git repo doesn't exist or similar.
-    rc_dirs.relink_current_to(rc_dirs.repo)
+    rc_dirs.change_current_to_target(rc_dirs.repo)
     # Link rc4me target config to destination
     rc_dirs.link_files()
 
@@ -73,7 +73,7 @@ def revert(ctx: Dict[str, RcDirs]):
     # Init rc4me directory variables
     rc_dirs = ctx.obj["rc_dirs"]
     logger.info("Reverting rc4me config to previous configuration")
-    rc_dirs.relink_current_to(rc_dirs.prev.resolve())
+    rc_dirs.change_current_to_target(rc_dirs.prev.resolve())
     # Link rc4me target config to destination
     rc_dirs.link_files()
 
@@ -90,7 +90,7 @@ def reset(ctx: Dict[str, RcDirs]):
     # Init rc4me directory variables
     rc_dirs = ctx.obj["rc_dirs"]
     logger.info("Restoring rc4me config to initial configuration")
-    rc_dirs.relink_current_to(rc_dirs.init)
+    rc_dirs.change_current_to_target(rc_dirs.init)
     # Link rc4me target config to destination
     rc_dirs.link_files()
 


### PR DESCRIPTION
Added function that unlinks the current symlinked files that exist in the `rc4me_home/current` before switching configurations.

## Changes
* added `RcDirs._unlink_current` function that does the above, with logs letting the user know files are being unlinked.
* restructured the utility functions so that functions with the form `f(RcDirs)` are now just methods of `RcDirs`
* changed log strings to be easier to read: "moving" -> "copying" and the files are always listed in the format "source->destination"

## Behaves differently
* `link_files` and `fetch_repo` are now methods of the `RcDirs` class instead of stand-alone functions, since there were no other dependencies.