### PR TITLE
Slim down docker image create requirements.txt for install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM manifoldai/orbyter-ml-dev:3.1
+FROM python:3.8
 
 WORKDIR /app/
-COPY setup.py /app/setup.py
 COPY rc4me /app/rc4me
-COPY tox.ini myproject.toml /app/
+COPY setup.py tox.ini myproject.toml /app/
 RUN pip install -e /app/
-
+COPY requirements.txt /app
+RUN pip install -r requirements.txt
 WORKDIR /app/

--- a/rc4me/conftest.py
+++ b/rc4me/conftest.py
@@ -1,5 +1,3 @@
-import filecmp  # use .samefile
-
 import pytest
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+black==20.8b1
+flake8==3.8.4
+isort==5.6.4
+pytest==6.1.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
     url="",
     version="0.0.0",
     packages=find_packages(),
-    install_requires=["Click"],
+    install_requires=["click>=7.1.2"],
+    python_requires=">=3.8",
     license="MIT License",
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
## Context

Base image we were using (`orbyter-ml-dev`) had a lot of pre-installed packages. Here, I slim the image up for two reason:
1. faster github actions
2. Make sure our `setup.py` is capturing the correct requirements

## Changes

* Switch images to `python:3.8`
* Fix random flake error

## Closes

#21 and #20 