### PR TITLE
RcDirs public interface refactor

### DIFF
--- a/rc4me/rcdirs_test.py
+++ b/rc4me/rcdirs_test.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from rc4me.util import RcDirs
+
+
+def test_init():
+    """TODO"""
+    dest = Path.home()
+    home = dest / ".rc4me"
+    rcd = RcDirs(home, dest)
+    assert rcd.home == home
+    assert rcd.dest == dest

--- a/rc4me/run.py
+++ b/rc4me/run.py
@@ -58,7 +58,8 @@ def get(ctx: Dict[str, RcDirs], repo: str):
     rc_dirs.fetch_repo(repo)
     # Wait to relink current until after _fetch_repo, since it could fail if
     # the git repo doesn't exist or similar.
-    rc_dirs.change_current_to_target(rc_dirs.repo)
+    # rc_dirs.change_current_to_target(rc_dirs.repo)
+    rc_dirs.change_current_to_fetched_repo()
     # Link rc4me target config to destination
     rc_dirs.link_files()
 
@@ -74,7 +75,7 @@ def revert(ctx: Dict[str, RcDirs]):
     # Init rc4me directory variables
     rc_dirs = ctx.obj["rc_dirs"]
     logger.info("Reverting rc4me config to previous configuration")
-    rc_dirs.change_current_to_target(rc_dirs.prev.resolve())
+    rc_dirs.change_current_to_prev()
     # Link rc4me target config to destination
     rc_dirs.link_files()
 
@@ -91,7 +92,7 @@ def reset(ctx: Dict[str, RcDirs]):
     # Init rc4me directory variables
     rc_dirs = ctx.obj["rc_dirs"]
     logger.info("Restoring rc4me config to initial configuration")
-    rc_dirs.change_current_to_target(rc_dirs.init)
+    rc_dirs.change_current_to_init()
     # Link rc4me target config to destination
     rc_dirs.link_files()
 

--- a/rc4me/util_test.py
+++ b/rc4me/util_test.py
@@ -9,6 +9,7 @@ def test_pass():
 
 
 def check_repo_files_in_home(repo: Path):
+    """Check that files in a repo are in the rc4me destination dir."""
     home_rcs = [f.name for f in Path("~").expanduser().glob(".*")]
     for f in repo.glob("*"):
         if f.is_file() and f.suffix != ".md":
@@ -19,7 +20,7 @@ def test_get():
     runner = CliRunner()
     result = runner.invoke(cli, ["get", "jeffmm/vimrc"])
     assert result.exit_code == 0
-    repo = Path("~/.rc4me/jeffmm/vimrc").expanduser()
+    repo = Path("~/.rc4me/jeffmm_vimrc").expanduser()
     assert repo.exists()
     assert repo.is_dir()
     check_repo_files_in_home(repo)

--- a/rc4me/util_test.py
+++ b/rc4me/util_test.py
@@ -1,3 +1,37 @@
+from pathlib import Path
+from click.testing import CliRunner
+from rc4me.run import cli
+
+
 def test_pass():
     """ Temp test before any written"""
+    pass
+
+
+def check_repo_files_in_home(repo: Path):
+    home_rcs = [f.name for f in Path("~").expanduser().glob(".*")]
+    for f in repo.glob("*"):
+        if f.is_file() and f.suffix != ".md":
+            assert f".{f.name}" in home_rcs
+
+
+def test_get():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["get", "jeffmm/vimrc"])
+    assert result.exit_code == 0
+    repo = Path("~/.rc4me/jeffmm/vimrc").expanduser()
+    assert repo.exists()
+    assert repo.is_dir()
+    check_repo_files_in_home(repo)
+
+
+def test_revert():
+    pass
+
+
+def test_reset():
+    pass
+
+
+def test_get_local():
     pass


### PR DESCRIPTION
# Context

Updated public interface of `RcDirs` to be more specific, and changed slashes in local repo names to underscores

# Changes

* `change_current_to_target` divided up into `change_current_to_init`, `change_current_to_repo`, and `change_current_to_prev`
* renamed `repo` property in `RcDirs` to `repo_path`
* added some more tests

# Behaves differently

* changed local repo paths to use an underscore between repo author and repo name (e.g. `jeffmm/vimrc` -> `jeffmm_vimrc`) so all local repos are at the same level in the `rc4me` home directory.
