### PR TITLE
Removed passing home flexibility

### DIFF
--- a/rc4me/cli.py
+++ b/rc4me/cli.py
@@ -16,26 +16,21 @@ logger = logging.getLogger(__name__)
 @click.group()
 # Allow calling function without an argument for --revert or --reset options
 @click.option("--dest", type=click.Path())
-@click.option("--home", type=click.Path())
 @click.pass_context
 def cli(
     ctx: Dict[str, RcManager],
-    home: Optional[str] = None,
     dest: Optional[str] = None,
 ) -> None:
     """Management for rc4me run commands."""
     # If the command was called without any arguments or options
     ctx.ensure_object(dict)
-    if home is None:
-        home = Path.home() / ".rc4me"
-    else:
-        home = Path(home)
     if dest is None:
         dest = Path.home()
     else:
         dest = Path(dest)
 
-    ctx.obj["rcmanager"] = RcManager(home, dest)
+    home = Path.home() / ".rc4me"
+    ctx.obj["rcmanager"] = RcManager(home=home, dest=dest)
 
 
 @click.argument("repo", required=True, type=str)

--- a/rc4me/rcmanager.py
+++ b/rc4me/rcmanager.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class RcManager:
     """Class for storing and manipulating rc4me home directory structure."""
 
-    def __init__(self, rc4me_home: Path, rc4me_dest: Path):
+    def __init__(self, home: Path = Path.home() / ".rc4me", dest: Path = Path.home()):
         """Initialize paths to home and source rc4me config repos.
 
         Creates attributes `source`, which is the path to the
@@ -22,13 +22,13 @@ class RcManager:
         directory.
 
         Args:
-            rc4me_home: Path to rc4me home directory.
-            rc4me_dest: Directory to copy rc files to.
+            home: Path to rc4me home directory.
+            dest: Directory to copy rc files to.
         """
         # Directory that holds all cloned rc config repos, and init, prev, current
-        self.home = rc4me_home
+        self.home = home
         # Directory to copy rc4me files to (e.g. $HOME)
-        self.dest = rc4me_dest
+        self.dest = dest
         # Init rc4me home dir variables (init, prev, current)
         self._init_rc4me_home()
         # Directory holding source file repo
@@ -162,7 +162,7 @@ class RcManager:
             git.Repo(repo).clone(self.repo_path, branch="master", depth=1)
         # Otherwise assume the repo refers to a remote GitHub repository
         else:
-            # Clone from GitHub to the rc4me_home directory
+            # Clone from GitHub to the home directory
             logger.info(f"Cloning GitHub repo {repo}")
             git.Repo.clone_from(
                 f"https://github.com/{repo}",
@@ -176,7 +176,7 @@ class RcManager:
 
         Transfers files found in the rc4me source directory and creates
         symlinks of them in the rc4me destination directory. If the source
-        directory is rc4me_home/init, the files are copied instead, allowing a
+        directory is home/init, the files are copied instead, allowing a
         user to safely delete their rc4me home dir after a reset.
         """
         # If we are restoring the initial config, copy the files rather than


### PR DESCRIPTION
# Context

I found having the `--home` option a little confusing, and I don't think adding the flexibility adds any benefit. Pretty much everything like this goes to `~/.myprogram`. Let's just stick with this.

# Changes

* Removed `--home` option

# Behaves Differently

* Can no longer pass `--home`

Closes #38. 
