### PR TITLE
Renamed get->apply and updated documentation for clarity

### DIFF
--- a/rc4me/cli.py
+++ b/rc4me/cli.py
@@ -15,7 +15,17 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 # Allow calling function without an argument for --revert or --reset options
-@click.option("--dest", type=click.Path())
+@click.option(
+    "--dest",
+    type=click.Path(),
+    default=Path.home(),
+    required=False,
+    help=(
+        "Destination path where run command files are copied/linked to. "
+        "Typically home or current directory"
+    ),
+    show_default=True,
+)
 @click.pass_context
 def cli(
     ctx: Dict[str, RcManager],
@@ -24,11 +34,6 @@ def cli(
     """Management for rc4me run commands."""
     # If the command was called without any arguments or options
     ctx.ensure_object(dict)
-    if dest is None:
-        dest = Path.home()
-    else:
-        dest = Path(dest)
-
     home = Path.home() / ".rc4me"
     ctx.obj["rcmanager"] = RcManager(home=home, dest=dest)
 
@@ -36,8 +41,8 @@ def cli(
 @click.argument("repo", required=True, type=str)
 @cli.command()
 @click.pass_context
-def get(ctx: Dict[str, RcManager], repo: str):
-    """Switch rc4me environment to target repo.
+def apply(ctx: Dict[str, RcManager], repo: str):
+    """Apply rc environment. Will download from GitHub if not found in .rc4me/
 
     Replaces rc files in rc4me home directory with symlinks to files located in
     target repo. If the target repo does not exist in the rc4me home directory,
@@ -89,7 +94,7 @@ def reset(ctx: Dict[str, RcManager]):
 @cli.command()
 @click.pass_context
 def select(ctx: Dict[str, RcManager]):
-    """Swap rc4me configurations
+    """Select rc4me configurations.
 
     Displays all available repos and allow user to select one
     """

--- a/rc4me/cli_test.py
+++ b/rc4me/cli_test.py
@@ -13,9 +13,9 @@ def check_repo_files_in_home(repo: Path):
             assert f".{f.name}" in home_rcs
 
 
-def test_get():
+def test_apply():
     runner = CliRunner()
-    result = runner.invoke(cli, ["get", "jeffmm/vimrc"])
+    result = runner.invoke(cli, ["apply", "jeffmm/vimrc"])
     assert result.exit_code == 0
     repo = Path("~/.rc4me/jeffmm_vimrc").expanduser()
     assert repo.exists()
@@ -25,11 +25,11 @@ def test_get():
 
 def test_revert():
     runner = CliRunner()
-    result = runner.invoke(cli, ["get", "mstefferson/rc-demo"])
+    result = runner.invoke(cli, ["apply", "mstefferson/rc-demo"])
     assert result.exit_code == 0
     ms_repo = Path("~/.rc4me/mstefferson_rc-demo").expanduser()
     check_repo_files_in_home(ms_repo)
-    result = runner.invoke(cli, ["get", "jeffmm/vimrc"])
+    result = runner.invoke(cli, ["apply", "jeffmm/vimrc"])
     assert result.exit_code == 0
     jm_repo = Path("~/.rc4me/jeffmm_vimrc").expanduser()
     check_repo_files_in_home(jm_repo)
@@ -40,7 +40,7 @@ def test_revert():
 
 def test_reset():
     runner = CliRunner()
-    result = runner.invoke(cli, ["get", "mstefferson/rc-demo"])
+    result = runner.invoke(cli, ["apply", "mstefferson/rc-demo"])
     repo = Path("~/.rc4me/mstefferson_rc-demo").expanduser()
     assert result.exit_code == 0
     result = runner.invoke(cli, ["reset"])
@@ -49,5 +49,5 @@ def test_reset():
     check_repo_files_in_home(repo)
 
 
-def test_get_local():
+def test_apply_local():
     pass


### PR DESCRIPTION
# Context

I found `get` confusing because it's doing more than just `get`ting the repo. It's linking it as well. I rename this and updated documentation to make things more clear.

# Changes

* Renamed `get` -> `apply`


# Behaves Differently

* CLI command

Closes #37 
